### PR TITLE
Handle Pstryk API 429 with endpoint backoff

### DIFF
--- a/custom_components/pstryk_aio/api.py
+++ b/custom_components/pstryk_aio/api.py
@@ -1,6 +1,7 @@
 """Klient API dla Pstryk.pl (uwierzytelnianie Kluczem API bezpośrednio w Authorization, endpointy /integrations/)."""
 import asyncio
 import logging
+import re
 from datetime import datetime, timedelta 
 from typing import Any, Dict, Optional
 
@@ -39,11 +40,22 @@ class PstrykApiClientApiKey:
         """Inicjalizacja klienta API."""
         self._api_key = api_key 
         self._session = session or aiohttp.ClientSession()
+        # Endpoint-level throttle backoff for API 429 responses.
+        self._throttle_until: Dict[str, datetime] = {}
 
     async def _request(self, method: str, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
         """Wykonuje żądanie do API Pstryk używając Klucza API bezpośrednio w nagłówku Authorization."""
         
         full_url = f"{API_BASE_URL}{path}"
+
+        throttle_until = self._throttle_until.get(path)
+        if throttle_until and dt_util.utcnow() < throttle_until:
+            _LOGGER.debug(
+                "Pomijam zapytanie do %s z powodu aktywnego backoff do %s",
+                full_url,
+                throttle_until,
+            )
+            return None
         
         request_headers = API_REQUEST_HEADERS.copy()
         request_headers["Authorization"] = self._api_key 
@@ -59,6 +71,22 @@ class PstrykApiClientApiKey:
                 if response.status in [401, 403]: 
                     _LOGGER.error(f"Błąd autoryzacji ({response.status}) dla {full_url}. Treść: {response_text_for_error_log[:500]}")
                     raise PstrykAuthError(f"Błąd autoryzacji ({response.status}). Sprawdź Klucz API. Treść błędu API: {response_text_for_error_log[:100]}")
+
+                if response.status == 429:
+                    cooldown_seconds = 3600
+                    match = re.search(r"Expected available in (\d+) seconds", response_text_for_error_log)
+                    if match:
+                        try:
+                            cooldown_seconds = int(match.group(1))
+                        except ValueError:
+                            pass
+                    self._throttle_until[path] = dt_util.utcnow() + timedelta(seconds=cooldown_seconds)
+                    _LOGGER.warning(
+                        "API throttling (429) dla %s. Ustawiam backoff na %s sekund.",
+                        full_url,
+                        cooldown_seconds,
+                    )
+                    return None
                 
                 response.raise_for_status() 
                 


### PR DESCRIPTION
## Summary
- add endpoint-level 429 backoff cache in `PstrykApiClientApiKey`
- skip requests while endpoint cooldown is active
- parse `Expected available in N seconds` from API response and default to 3600s
- return `None` on throttled requests to avoid repeated error spam

## Why
The integration can hit Pstryk API rate limits and repeatedly log errors. This change adds controlled cooldown behavior per endpoint to reduce API pressure and log noise while preserving graceful fallback behavior.

## Validation
- `python3 -m py_compile custom_components/pstryk_aio/api.py`
