### PR TITLE
Update pstryk integration for unified metrics API

### DIFF
--- a/custom_components/pstryk_aio/__init__.py
+++ b/custom_components/pstryk_aio/__init__.py
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     async def async_update_data():
         """Pobiera najnowsze dane z API Pstryk przy użyciu Klucza API."""
-        _LOGGER.debug("Rozpoczynanie aktualizacji danych dla Pstryk AIO (Klucz API, /integrations/)")
+        _LOGGER.debug("Rozpoczynanie aktualizacji danych dla Pstryk AIO (Klucz API, unified-metrics + pricing)")
         
         try:
             now_in_ha_tz = dt_util.now()
@@ -68,7 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 window_end=meter_data_history_end_utc
             )
             if meter_data_usage_response is None:
-                _LOGGER.warning("Nie udało się pobrać danych z /integrations/meter-data/energy-usage/.")
+                _LOGGER.warning("Nie udało się pobrać danych zużycia z unified-metrics (metrics=meter_values).")
             
             # Pobierz dane o kosztach (fae_cost, rae_cost)
             meter_data_cost_response = await api_client.get_integrations_meter_data_cost(
@@ -77,7 +77,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 window_end=meter_data_history_end_utc
             )
             if meter_data_cost_response is None:
-                _LOGGER.warning("Nie udało się pobrać danych z /integrations/meter-data/energy-cost/.")
+                _LOGGER.warning("Nie udało się pobrać danych kosztowych z unified-metrics (metrics=cost).")
 
             refresh_today_purchase_prices = (
                 coordinator._date_prices_today_fetched != current_local_date or
@@ -264,7 +264,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 KEY_LAST_UPDATE: dt_util.utcnow().isoformat(),
             }
             _LOGGER.info(
-                f"Pomyślnie pobrano dane dla Pstryk AIO (Klucz API, /integrations/). "
+                f"Pomyślnie pobrano dane dla Pstryk AIO (Klucz API, unified-metrics/pricing). "
                 f"Usage: {'OK' if meter_data_usage_response else 'FAIL'}, "
                 f"Cost: {'OK' if meter_data_cost_response else 'FAIL'}, "
                 f"PurchasePricesToday: {'OK' if pricing_purchase_today_response and pricing_purchase_today_response.get('frames') else 'FAIL_EMPTY'}, "

--- a/custom_components/pstryk_aio/api.py
+++ b/custom_components/pstryk_aio/api.py
@@ -1,7 +1,7 @@
-"""Klient API dla Pstryk.pl (uwierzytelnianie Kluczem API bezpośrednio w Authorization, endpointy /integrations/)."""
+"""Klient API dla Pstryk.pl (uwierzytelnianie Kluczem API w Authorization)."""
 import asyncio
 import logging
-from datetime import datetime, timedelta 
+from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
 
 import aiohttp
@@ -9,15 +9,62 @@ from homeassistant.util import dt as dt_util
 
 from .const import (
     API_BASE_URL,
-    API_METER_DATA_USAGE_PATH,
-    API_METER_DATA_COST_PATH,
-    API_PRICING_PATH,
+    API_UNIFIED_METRICS_PATH,
     API_PROSUMER_PRICING_PATH,
     API_REQUEST_HEADERS,
     API_TIMEOUT,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+UNIFIED_METRIC_METER_VALUES = "meter_values"
+UNIFIED_METRIC_COST = "cost"
+UNIFIED_METRIC_PRICING = "pricing"
+
+UNIFIED_METER_VALUES_RESPONSE_KEYS = ("meterValues", "meter_values")
+UNIFIED_COST_RESPONSE_KEYS = ("cost",)
+UNIFIED_PRICING_RESPONSE_KEYS = ("pricing",)
+
+
+def _pick_value(payload: Optional[Dict[str, Any]], *keys: str) -> Any:
+    """Zwróć pierwszą dostępną wartość z payload."""
+    if not isinstance(payload, dict):
+        return None
+    for key in keys:
+        if key in payload:
+            return payload.get(key)
+    return None
+
+
+def _pick_metric_container(payload: Optional[Dict[str, Any]], keys: tuple[str, ...]) -> Dict[str, Any]:
+    """Znajdź słownik metryki w odpowiedzi unified-metrics."""
+    if not isinstance(payload, dict):
+        return {}
+
+    metrics = payload.get("metrics")
+    if isinstance(metrics, dict):
+        nested_metric = _pick_value(metrics, *keys)
+        if isinstance(nested_metric, dict):
+            return nested_metric
+
+    direct_metric = _pick_value(payload, *keys)
+    if isinstance(direct_metric, dict):
+        return direct_metric
+
+    return {}
+
+
+def _sum_numeric_frames(frames: list[Dict[str, Any]], key: str) -> Optional[float]:
+    """Zsumuj wartości liczbowe z ramek."""
+    total = 0.0
+    found = False
+    for frame in frames:
+        value = frame.get(key)
+        if isinstance(value, (int, float)):
+            total += float(value)
+            found = True
+    return round(total, 6) if found else None
 
 
 class PstrykApiError(Exception):
@@ -29,7 +76,7 @@ class PstrykAuthError(PstrykApiError):
 
 
 class PstrykApiClientApiKey:
-    """Asynchroniczny klient API Pstryk.pl (uwierzytelnianie Kluczem API bezpośrednio w Authorization)."""
+    """Asynchroniczny klient API Pstryk.pl."""
 
     def __init__(
         self,
@@ -41,13 +88,12 @@ class PstrykApiClientApiKey:
         self._session = session or aiohttp.ClientSession()
 
     async def _request(self, method: str, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
-        """Wykonuje żądanie do API Pstryk używając Klucza API bezpośrednio w nagłówku Authorization."""
-        
+        """Wykonuje żądanie do API Pstryk używając Klucza API w nagłówku Authorization."""
         full_url = f"{API_BASE_URL}{path}"
-        
+
         request_headers = API_REQUEST_HEADERS.copy()
-        request_headers["Authorization"] = self._api_key 
-        
+        request_headers["Authorization"] = self._api_key
+
         _LOGGER.debug(f"Wysyłanie żądania (API Key in Authorization): {method} {full_url}, params: {params}, headers: {request_headers}")
         response_text_for_error_log = ""
 
@@ -66,7 +112,7 @@ class PstrykApiClientApiKey:
                     return await response.json()
                 else:
                     _LOGGER.warning(f"Odpowiedź z {full_url} nie jest typu JSON (Content-Type: {response.headers.get('Content-Type')}). Zwracam tekst: {response_text_for_error_log[:200]}")
-                    return response_text_for_error_log 
+                    return response_text_for_error_log
 
         except aiohttp.ClientResponseError as err: 
             if err.status not in [401, 403]: # PstrykAuthError powinien być już rzucony
@@ -90,12 +136,231 @@ class PstrykApiClientApiKey:
             else:
                 raise
 
+    async def _request_unified_metrics(
+        self, metrics: str, resolution: str, window_start: datetime, window_end: datetime
+    ) -> Optional[Dict[str, Any]]:
+        """Pobiera dane z nowego endpointu unified-metrics."""
+        start_str = window_start.strftime("%Y-%m-%dT%H:%M:%SZ")
+        end_str = window_end.strftime("%Y-%m-%dT%H:%M:%SZ")
+        params = {
+            "metrics": metrics,
+            "resolution": resolution,
+            "window_start": start_str,
+            "window_end": end_str,
+        }
+        try:
+            return await self._request("GET", API_UNIFIED_METRICS_PATH, params=params)
+        except PstrykApiError as err:
+            _LOGGER.warning(
+                "Nie udało się pobrać danych z %s dla metrics=%s: %s",
+                API_UNIFIED_METRICS_PATH,
+                metrics,
+                err,
+            )
+            return None
+
+    def _normalize_unified_usage_response(self, response_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Mapuje unified-metrics na format oczekiwany przez integrację."""
+        if not isinstance(response_data, dict):
+            return response_data
+
+        normalized_frames: list[Dict[str, Any]] = []
+        for frame in response_data.get("frames", []):
+            if not isinstance(frame, dict):
+                continue
+
+            meter_values = _pick_metric_container(frame, UNIFIED_METER_VALUES_RESPONSE_KEYS)
+            normalized_frame: Dict[str, Any] = {
+                "start": frame.get("start"),
+                "end": frame.get("end"),
+                "fae_usage": _pick_value(
+                    meter_values,
+                    "fae_usage",
+                    "energy_active_import_register",
+                ),
+                "rae": _pick_value(
+                    meter_values,
+                    "rae",
+                    "energy_active_export_register",
+                ),
+                "energy_balance": _pick_value(
+                    meter_values,
+                    "energy_balance",
+                    "energy_balance_total",
+                ),
+            }
+            if frame.get("is_live") is not None:
+                normalized_frame["is_live"] = frame.get("is_live")
+            normalized_frames.append(normalized_frame)
+
+        summary = _pick_metric_container(response_data.get("summary"), UNIFIED_METER_VALUES_RESPONSE_KEYS)
+        normalized_response: Dict[str, Any] = {
+            "resolution": response_data.get("resolution"),
+            "frames": normalized_frames,
+        }
+        if response_data.get("name") is not None:
+            normalized_response["name"] = response_data.get("name")
+
+        normalized_response["fae_total_usage"] = _pick_value(
+            summary,
+            "fae_total_usage",
+            "energy_active_import_register_total",
+        )
+        normalized_response["rae_total"] = _pick_value(
+            summary,
+            "rae_total",
+            "energy_active_export_register_total",
+        )
+        normalized_response["energy_balance"] = _pick_value(
+            summary,
+            "energy_balance",
+            "energy_balance_total",
+        )
+
+        if normalized_response["fae_total_usage"] is None:
+            normalized_response["fae_total_usage"] = _sum_numeric_frames(normalized_frames, "fae_usage")
+        if normalized_response["rae_total"] is None:
+            normalized_response["rae_total"] = _sum_numeric_frames(normalized_frames, "rae")
+        if normalized_response["energy_balance"] is None:
+            normalized_response["energy_balance"] = _sum_numeric_frames(normalized_frames, "energy_balance")
+
+        return normalized_response
+
+    def _normalize_unified_cost_response(self, response_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Mapuje unified-metrics na kosztowy format oczekiwany przez integrację."""
+        if not isinstance(response_data, dict):
+            return response_data
+
+        normalized_frames: list[Dict[str, Any]] = []
+        for frame in response_data.get("frames", []):
+            if not isinstance(frame, dict):
+                continue
+
+            cost_values = _pick_metric_container(frame, UNIFIED_COST_RESPONSE_KEYS)
+            normalized_frame: Dict[str, Any] = {
+                "start": frame.get("start"),
+                "end": frame.get("end"),
+                "fae_cost": _pick_value(
+                    cost_values,
+                    "fae_cost",
+                    "total_cost",
+                    "energy_active_import_register_cost",
+                ),
+                "energy_sold_value": _pick_value(
+                    cost_values,
+                    "energy_sold_value",
+                    "energy_active_export_register_value",
+                    "energy_active_export_register_revenue",
+                ),
+                "energy_balance_value": _pick_value(
+                    cost_values,
+                    "energy_balance_value",
+                    "net_cost",
+                ),
+            }
+            if frame.get("is_live") is not None:
+                normalized_frame["is_live"] = frame.get("is_live")
+
+            if normalized_frame["energy_balance_value"] is None:
+                fae_cost = normalized_frame.get("fae_cost")
+                sold_value = normalized_frame.get("energy_sold_value")
+                if isinstance(fae_cost, (int, float)) and isinstance(sold_value, (int, float)):
+                    normalized_frame["energy_balance_value"] = round(float(fae_cost) - float(sold_value), 6)
+
+            normalized_frames.append(normalized_frame)
+
+        summary = _pick_metric_container(response_data.get("summary"), UNIFIED_COST_RESPONSE_KEYS)
+        normalized_response: Dict[str, Any] = {
+            "resolution": response_data.get("resolution"),
+            "frames": normalized_frames,
+        }
+
+        normalized_response["fae_total_cost"] = _pick_value(
+            summary,
+            "fae_total_cost",
+            "total_cost_total",
+            "energy_active_import_register_cost_total",
+        )
+        normalized_response["total_energy_sold_value"] = _pick_value(
+            summary,
+            "total_energy_sold_value",
+            "energy_active_export_register_value_total",
+            "energy_active_export_register_revenue_total",
+        )
+        normalized_response["total_energy_balance_value"] = _pick_value(
+            summary,
+            "total_energy_balance_value",
+            "net_cost_total",
+        )
+
+        if normalized_response["fae_total_cost"] is None:
+            normalized_response["fae_total_cost"] = _sum_numeric_frames(normalized_frames, "fae_cost")
+        if normalized_response["total_energy_sold_value"] is None:
+            normalized_response["total_energy_sold_value"] = _sum_numeric_frames(normalized_frames, "energy_sold_value")
+        if normalized_response["total_energy_balance_value"] is None:
+            normalized_response["total_energy_balance_value"] = _sum_numeric_frames(normalized_frames, "energy_balance_value")
+
+        return normalized_response
+
+    def _normalize_unified_pricing_response(self, response_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        """Mapuje unified-metrics na płaski format cenowy."""
+        if not isinstance(response_data, dict):
+            return response_data
+
+        normalized_frames: list[Dict[str, Any]] = []
+        for frame in response_data.get("frames", []):
+            if not isinstance(frame, dict):
+                continue
+
+            pricing_values = _pick_metric_container(frame, UNIFIED_PRICING_RESPONSE_KEYS)
+            normalized_frame: Dict[str, Any] = {
+                "start": frame.get("start"),
+                "end": frame.get("end"),
+                "price_net": _pick_value(pricing_values, "price_net", "price_net_avg"),
+                "price_gross": _pick_value(pricing_values, "price_gross", "price_gross_avg"),
+                "is_cheap": _pick_value(pricing_values, "is_cheap"),
+                "is_expensive": _pick_value(pricing_values, "is_expensive"),
+            }
+            is_live = frame.get("is_live")
+            if is_live is None:
+                is_live = _pick_value(pricing_values, "is_live")
+            if is_live is not None:
+                normalized_frame["is_live"] = is_live
+            normalized_frames.append(normalized_frame)
+
+        summary = _pick_metric_container(response_data.get("summary"), UNIFIED_PRICING_RESPONSE_KEYS)
+        normalized_response: Dict[str, Any] = {
+            "frames": normalized_frames,
+            "price_net_avg": _pick_value(summary, "price_net_avg"),
+            "price_gross_avg": _pick_value(summary, "price_gross_avg"),
+        }
+
+        if normalized_response["price_net_avg"] is None:
+            normalized_response["price_net_avg"] = _sum_numeric_frames(normalized_frames, "price_net")
+            if normalized_response["price_net_avg"] is not None and normalized_frames:
+                normalized_response["price_net_avg"] = round(
+                    normalized_response["price_net_avg"] / len(normalized_frames), 6
+                )
+
+        if normalized_response["price_gross_avg"] is None:
+            normalized_response["price_gross_avg"] = _sum_numeric_frames(normalized_frames, "price_gross")
+            if normalized_response["price_gross_avg"] is not None and normalized_frames:
+                normalized_response["price_gross_avg"] = round(
+                    normalized_response["price_gross_avg"] / len(normalized_frames), 6
+                )
+
+        return normalized_response
+
     async def test_authentication(self) -> bool:
-        """Testuje autentykację Kluczem API poprzez próbę pobrania danych z /integrations/meter-data/energy-usage/."""
+        """Testuje autentykację Kluczem API poprzez próbę pobrania danych unified-metrics."""
         try:
             now = dt_util.utcnow()
-            start_time = now - timedelta(days=1) 
-            _LOGGER.debug(f"Test autoryzacji: próba pobrania danych z {API_METER_DATA_USAGE_PATH} (API Key in Authorization)")
+            start_time = now - timedelta(days=1)
+            _LOGGER.debug(
+                "Test autoryzacji: próba pobrania danych z %s (metrics=%s)",
+                API_UNIFIED_METRICS_PATH,
+                UNIFIED_METRIC_METER_VALUES,
+            )
             meter_data = await self.get_integrations_meter_data_usage(
                 resolution="day", window_start=start_time, window_end=now
             )
@@ -116,37 +381,34 @@ class PstrykApiClientApiKey:
             return False
 
     async def get_integrations_meter_data_usage(self, resolution: str, window_start: datetime, window_end: datetime) -> Optional[Dict[str, Any]]:
-        """Pobiera dane z /integrations/meter-data/energy-usage/."""
-        start_str = window_start.strftime('%Y-%m-%dT%H:%M:%SZ')
-        end_str = window_end.strftime('%Y-%m-%dT%H:%M:%SZ')
-        params = {"resolution": resolution, "window_start": start_str, "window_end": end_str}
-        try:
-            return await self._request("GET", API_METER_DATA_USAGE_PATH, params=params)
-        except PstrykApiError as e:
-            _LOGGER.warning(f"Nie udało się pobrać danych z {API_METER_DATA_USAGE_PATH}: {e}")
-            return None
+        """Pobiera dane zużycia z unified-metrics i normalizuje je do starego formatu."""
+        response_data = await self._request_unified_metrics(
+            metrics=UNIFIED_METRIC_METER_VALUES,
+            resolution=resolution,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        return self._normalize_unified_usage_response(response_data)
 
     async def get_integrations_meter_data_cost(self, resolution: str, window_start: datetime, window_end: datetime) -> Optional[Dict[str, Any]]:
-        """Pobiera dane o kosztach z /integrations/meter-data/energy-cost/."""
-        start_str = window_start.strftime('%Y-%m-%dT%H:%M:%SZ')
-        end_str = window_end.strftime('%Y-%m-%dT%H:%M:%SZ')   
-        params = {"resolution": resolution, "window_start": start_str, "window_end": end_str}
-        try:
-            return await self._request("GET", API_METER_DATA_COST_PATH, params=params) 
-        except PstrykApiError as e:
-            _LOGGER.warning(f"Nie udało się pobrać danych z {API_METER_DATA_COST_PATH} (koszty): {e}")
-            return None
+        """Pobiera dane kosztowe z unified-metrics i normalizuje je do starego formatu."""
+        response_data = await self._request_unified_metrics(
+            metrics=UNIFIED_METRIC_COST,
+            resolution=resolution,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        return self._normalize_unified_cost_response(response_data)
 
     async def get_integrations_pricing_data(self, resolution: str, window_start: datetime, window_end: datetime) -> Optional[Dict[str, Any]]:
-        """Pobiera dane cenowe zakupu z /integrations/pricing/."""
-        start_str = window_start.strftime('%Y-%m-%dT%H:%M:%SZ')
-        end_str = window_end.strftime('%Y-%m-%dT%H:%M:%SZ')   
-        params = {"resolution": resolution, "window_start": start_str, "window_end": end_str}
-        try:
-            return await self._request("GET", API_PRICING_PATH, params=params) 
-        except PstrykApiError as e:
-            _LOGGER.warning(f"Nie udało się pobrać danych z {API_PRICING_PATH} (ceny zakupu): {e}")
-            return None
+        """Pobiera dane cenowe zakupu z unified-metrics i normalizuje je do starego formatu."""
+        response_data = await self._request_unified_metrics(
+            metrics=UNIFIED_METRIC_PRICING,
+            resolution=resolution,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        return self._normalize_unified_pricing_response(response_data)
 
     async def get_integrations_prosumer_pricing_data(self, resolution: str, window_start: datetime, window_end: datetime) -> Optional[Dict[str, Any]]:
         """Pobiera dane cenowe sprzedaży (prosument) z /integrations/prosumer-pricing/."""

--- a/custom_components/pstryk_aio/config_flow.py
+++ b/custom_components/pstryk_aio/config_flow.py
@@ -92,7 +92,7 @@ class PstrykConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         usage_data = await api_client.get_integrations_meter_data_usage(
                             resolution="day", window_start=start_time, window_end=now
                         )
-                        _LOGGER.debug(f"Odpowiedź z get_integrations_meter_data_usage podczas config_flow: {str(usage_data)[:1000]}")
+                        _LOGGER.debug(f"Odpowiedź z unified-metrics (meter_values) podczas config_flow: {str(usage_data)[:1000]}")
 
                         if usage_data and isinstance(usage_data, dict):
                             name_from_api = usage_data.get("name") 
@@ -100,9 +100,9 @@ class PstrykConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                                 entry_title = f"{DEFAULT_NAME} {name_from_api.strip()}"
                                 _LOGGER.info(f"Pomyślnie pobrano nazwę licznika dla tytułu wpisu: {name_from_api}")
                             else:
-                                _LOGGER.debug("Klucz 'name' nie znaleziony lub pusty w odpowiedzi z energy-usage. Używam domyślnego tytułu.")
+                                _LOGGER.debug("Klucz 'name' nie znaleziony lub pusty w odpowiedzi z unified-metrics. Używam domyślnego tytułu.")
                         else:
-                            _LOGGER.debug("Brak danych lub nieprawidłowy format odpowiedzi z energy-usage. Używam domyślnego tytułu.")
+                            _LOGGER.debug("Brak danych lub nieprawidłowy format odpowiedzi z unified-metrics. Używam domyślnego tytułu.")
                     except Exception as e:
                         _LOGGER.warning(
                             f"Nie udało się pobrać/przetworzyć nazwy licznika dla tytułu wpisu, używam domyślnego. Błąd: {e}"

--- a/custom_components/pstryk_aio/const.py
+++ b/custom_components/pstryk_aio/const.py
@@ -33,6 +33,7 @@ KEY_LAST_UPDATE = "last_api_update"
 API_BASE_URL = "https://api.pstryk.pl" 
 API_TIMEOUT = 20
 # Ścieżki API dla endpointów /integrations/
+API_UNIFIED_METRICS_PATH = "/integrations/meter-data/unified-metrics/"
 API_METER_DATA_USAGE_PATH = "/integrations/meter-data/energy-usage/"
 API_METER_DATA_COST_PATH = "/integrations/meter-data/energy-cost/"
 API_PRICING_PATH = "/integrations/pricing/" 


### PR DESCRIPTION
  - Migracja pstryk_aio na nowe API Pstryk zgodne ze Swaggerem.
  - Zastąpienie wygaszanych endpointów licznikowych /energy-usage/ i /energy-
    cost/ nowym /integrations/meter-data/unified-metrics/.
  - Dodanie mapowania nowej odpowiedzi API do dotychczasowego formatu używanego
    przez sensory, bez zmiany ich logiki.
  - Aktualizacja testu autoryzacji i logów, żeby wskazywały nowy endpoint.
  - Zachowanie obecnej obsługi cen prosumenckich na istniejącym endpointzie.
  - Weryfikacja lokalna (py_compile) i test na żywym Home Assistant: ha core
    check, restart oraz potwierdzenie, że encje sensor.pstryk_aio_* dalej
    poprawnie się aktualizują.